### PR TITLE
Prevent exporting disabled products (BESWT-39)

### DIFF
--- a/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Repository/ProductRepository.php
+++ b/src/Pim/Bundle/CatalogBundle/Doctrine/MongoDBODM/Repository/ProductRepository.php
@@ -171,6 +171,8 @@ class ProductRepository extends DocumentRepository implements
             $qb->expr()->field('categoryIds')->in($categoryIds)
         );
 
+        $qb->addAnd($qb->expr()->field('enabled')->equals(true));
+
         return $qb;
     }
 


### PR DESCRIPTION
[BESWT-39](https://ampersand.atlassian.net/browse/BESWT-39)
[Akeneo issue](https://github.com/akeneo/pim-community-dev/issues/5748)
[Akeneo PR](https://github.com/akeneo/pim-community-dev/pull/5749)

Add condition to check if product is enabled so `ODMProductReader` does not read and export disabled products. This check already exists in `ORMProductReader`.